### PR TITLE
do not add the gpg agent if people don't want it or already have it

### DIFF
--- a/mac.sh
+++ b/mac.sh
@@ -145,8 +145,15 @@ max-cache-ttl 86400
 EOF
 
 # enable SSH
-echo 'export "SSH_AUTH_SOCK=${HOME}/.gnupg/S.gpg-agent.ssh"' >> ~/.bash_profile
-echo 'export "SSH_AUTH_SOCK=${HOME}/.gnupg/S.gpg-agent.ssh"' >> ~/.zshrc
+read -p "Would you like the gpg agent to be added to your bash and zsh profiles? [y/n] " -n 1 -r
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+  if [[ $(cat ~/.bash_profile) =~ "gpg-agent.ssh" ]]; then
+    echo 'export "SSH_AUTH_SOCK=${HOME}/.gnupg/S.gpg-agent.ssh"' >> ~/.bash_profile
+  fi
+  if [[ $(cat ~/.zshrc) =~ "gpg-agent.ssh" ]]; then
+    echo 'export "SSH_AUTH_SOCK=${HOME}/.gnupg/S.gpg-agent.ssh"' >> ~/.zshrc
+  fi
+fi
 
 # restart GPG daemons to pick up pinentry-mac
 $GPGCONF --kill all


### PR DESCRIPTION
Running this for my backup resulted in a doubling of these lines, because I've already added it manually. We should ask because it might be in another file, instead of the main one, because a lot of people break this out into multiple files