### PR TITLE
Fixup

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ command-line option, with only `curl` and `gpg`, and without installing any
 Keybase app, or uploading an encrypted copy of your private key. For example,
 see this [profile](https://keybase.io/trishankdatadog).
 
+If you have the [Keybase application](https://keybase.io/docs/the_app/install_macos)
+installed, you can import your Yubikey public key like this:
+
+```bash
+$ keybase pgp select
+
+# If you already have a primary Keybase public key, use the --multi flag to import another
+$ keybase pgp select --multi
+```
+
+See `keybase pgp help select` for more detail.
+
 ## VMware Fusion
 
 Optional: using YubiKey inside GNU/Linux running on VMware Fusion.

--- a/git.sh
+++ b/git.sh
@@ -3,8 +3,6 @@
 # Stop on error.
 set -e
 
-brew install --force git
-
 source realname-and-email.sh
 
 # Set git name and email.

--- a/gpg.sh
+++ b/gpg.sh
@@ -10,7 +10,7 @@ echo ""
 # install required tools
 echo "Installing required tools, please try a full upgrade with 'brew upgrade --force'"
 echo "of the problematic packages if something goes wrong, then try again."
-brew install --force expect gnupg pinentry-mac ykman
+brew install --force expect gnupg pinentry-mac ykman git
 echo ""
 
 # Get full name and email address.


### PR DESCRIPTION
Thanks for making these handy set up scripts! This PR has two changes:

* `gpg.sh` will exit with an error if Homebrew git is not yet installed. This dependency is installed in `git.sh`, so if you run the scripts in the order suggested by the readme on a fresh install, you get an error and have to debug. Since the git script already expects the gpg script to have run first, this PR moves installation of git there.

* Adds a snippet to the readme for Keybase cli users