### PR TITLE
Multiple fix on ssh.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,11 +248,11 @@ here. Make sure you enter your **Admin PIN** correctly within 3x, otherwise
 your current keys are blocked, and you must reset your YubiKey to use new keys.
 
 ### Error with git pull/fetch or when using SSH
-If when you try to ssh or git pull/fetch and you have the error:
+If you try to ssh or git pull/fetch and you have the following error:
 ```
 sign_and_send_pubkey: signing failed: agent refused operation
 ```
-You are probably misstyping you PIN. To verify it, you can:
+You are probably mistyping your PIN. To verify it, you can:
 ```
 gpg --card-edit
 gpg/card> verify
@@ -261,8 +261,8 @@ PIN retry counter : 3 0 3 # if it is the right PIN
 PIN retry counter : 2 0 3 # if it is a wrong PIN
 ...
 ```
-If you the PIN is wrong, try 123456 which is the default PIN.
-If it still fails, reset your password:
+If your PIN is wrong, try 123456, which is the default PIN.
+If it still fails, reset your PIN:
 ```
 gpg --card-edit
 gpg/card> admin

--- a/README.md
+++ b/README.md
@@ -247,6 +247,41 @@ instructions](https://github.com/ruimarinho/yubikey-handbook/blob/master/openpgp
 here. Make sure you enter your **Admin PIN** correctly within 3x, otherwise
 your current keys are blocked, and you must reset your YubiKey to use new keys.
 
+### Error with git pull/fetch or when using SSH
+If when you try to ssh or git pull/fetch and you have the error:
+```
+sign_and_send_pubkey: signing failed: agent refused operation
+```
+You are probably misstyping you PIN. To verify it, you can:
+```
+gpg --card-edit
+gpg/card> verify
+...
+PIN retry counter : 3 0 3 # if it is the right PIN
+PIN retry counter : 2 0 3 # if it is a wrong PIN
+...
+```
+If you the PIN is wrong, try 123456 which is the default PIN.
+If it still fails, reset your password:
+```
+gpg --card-edit
+gpg/card> admin
+gpg/card> passwd
+gpg: OpenPGP card no. D2760001240102010006055532110000 detected
+
+Your selection? 1
+PIN changed.
+
+1 - change PIN
+2 - unblock PIN
+3 - change Admin PIN
+4 - set the Reset Code
+Q - quit
+
+Your selection? q
+```
+
+
 ### git rebase
 
 Combined with the touch requirement for all signing operations, `git rebase`

--- a/env.sh
+++ b/env.sh
@@ -10,6 +10,9 @@ GPG=$HOMEBREW_BIN/gpg
 GPG_AGENT=$HOMEBREW_BIN/gpg-agent
 GPGCONF=$HOMEBREW_BIN/gpgconf
 YKMAN=$HOMEBREW_BIN/ykman
+BOLD=$(tput bold)
+RED=$(tput setaf 1)
+RESET=$(tput sgr0) # Reset text
 
 SSH_ENV="$HOME/.ssh/environment"
 

--- a/gpg.sh
+++ b/gpg.sh
@@ -153,7 +153,7 @@ $GPGCONF --kill all
 
 # Final reminders.
 echo "Finally, remember that your keys will not expire until 10 years from now."
-echo "You will need to enter your PIN (once a day), and touch your Yubikey everytime in order to sign any message with this GPG key."
+echo "You will need to ${RED}${BOLD}enter your PIN (once a day)${RESET}, and ${RED}${BOLD}touch your Yubikey everytime${RESET} in order to sign any message with this GPG key."
 echo ""
 echo "************************************************************"
 echo "Your PIN is: $PIN"

--- a/ssh.sh
+++ b/ssh.sh
@@ -15,7 +15,7 @@ configure_shell() {
             if [[ "$(basename "$config_file")" == "config.fish" ]]; then
                 echo 'set -gx SSH_AUTH_SOCK ${HOME}/.gnupg/S.gpg-agent.ssh' >> "${config_file}"
             else
-                echo 'export "SSH_AUTH_SOCK=${HOME}/.gnupg/S.gpg-agent.ssh"' >> "${HOME}/.zshrc"
+                echo 'export "SSH_AUTH_SOCK=${HOME}/.gnupg/S.gpg-agent.ssh"' >> "${config_file}"
             fi
         fi
         set +e

--- a/ssh.sh
+++ b/ssh.sh
@@ -48,8 +48,6 @@ for configuration_file in ${configuration_files[@]}; do
     configure_shell "$configuration_file"
 done
 
-ssh-add -L
-
 # Export SSH key derived from GPG authentication subkey.
 KEYID=$(get_keyid "$DEFAULT_GPG_HOMEDIR")
 SSH_PUBKEY=$KEYID.ssh.pub

--- a/ssh.sh
+++ b/ssh.sh
@@ -30,7 +30,7 @@ configure_shell() {
             echo 'export "SSH_AUTH_SOCK=${HOME}/.gnupg/S.gpg-agent.ssh"' >> "${config_file}"
         fi
     fi
-    # Avoid bad config file to force us to fail
+    # put set +e before sourcing the rc file just in case people have things that return 1 in it
     set +e
     source "${config_file}" > /dev/null 2>&1
     set -e
@@ -69,3 +69,6 @@ echo "Please save a copy in your password manager."
 read -p "Have you done this? "
 echo "Great."
 echo ""
+echo "You will need to ${RED}${BOLD}enter your PIN (once a day)${RESET}, and ${RED}${BOLD}touch your Yubikey everytime${RESET} in order to use SSH."
+echo ""
+echo "Enjoy using your Yubikey at Datadog!"

--- a/ssh.sh
+++ b/ssh.sh
@@ -9,19 +9,23 @@ configure_shell() {
     local config_file
     config_file="$1"
 
-    if [[ -f "${config_file}" ]]; then
-        echo "$(basename "$config_file") detected"
-        if ! grep -q "gpg-agent.ssh" "$config_file"; then
-            if [[ "$(basename "$config_file")" == "config.fish" ]]; then
-                echo 'set -gx SSH_AUTH_SOCK ${HOME}/.gnupg/S.gpg-agent.ssh' >> "${config_file}"
-            else
-                echo 'export "SSH_AUTH_SOCK=${HOME}/.gnupg/S.gpg-agent.ssh"' >> "${config_file}"
-            fi
+    echo "$(basename "$config_file") detected"
+    if ! grep -q "gpg-agent.ssh" "$config_file"; then
+        if [[ "$(basename "$config_file")" == "config.fish" ]]; then
+            echo 'set -gx SSH_AUTH_SOCK ${HOME}/.gnupg/S.gpg-agent.ssh' >> "${config_file}"
+        else
+            echo 'export "SSH_AUTH_SOCK=${HOME}/.gnupg/S.gpg-agent.ssh"' >> "${config_file}"
         fi
-        set +e
-        source "${config_file}" > /dev/null 2>&1
-        set -e
     fi
+    # Avoid bad config file to force us to fail
+    set +e
+    source "${config_file}" > /dev/null 2>&1
+    set -e
+    if [[ "$SSH_AUTH_SOCK" != "${HOME}/.gnupg/S.gpg-agent.ssh" ]]; then
+        echo "Failed to configure SSH_AUTH_SOCK into $config_file"
+        return 1
+    fi
+
 }
 
 if ! grep -q "enable-ssh-support" "$DEFAULT_GPG_AGENT_CONF"; then
@@ -37,16 +41,22 @@ if [[ -f "$SSH_ENV" ]]; then
     rm -f "$SSH_ENV"
 fi
 
-configuration_files=(
-"${HOME}/.config/fish/config.fish"
-"${HOME}/.zshrc"
-"${HOME}/.bash_profile"
-"${HOME}/.profile"
-)
+case $(/usr/bin/basename "$SHELL") in
+    bash)
+        configuration_file="${HOME}/.bashrc"
+        ;;
+    zsh)
+        configuration_file="${HOME}/.zshrc"
+        ;;
+    fish)
+        configuration_file="${HOME}/.config/fish/config.fish"
+        ;;
+    *)
+        configuration_file="${HOME}/.profile"
+        ;;
+esac
+configure_shell "$configuration_file"
 
-for configuration_file in ${configuration_files[@]}; do
-    configure_shell "$configuration_file"
-done
 
 # Export SSH key derived from GPG authentication subkey.
 KEYID=$(get_keyid "$DEFAULT_GPG_HOMEDIR")
@@ -62,3 +72,4 @@ echo "Please save a copy in your password manager."
 read -p "Have you done this? "
 echo "Great."
 echo ""
+


### PR DESCRIPTION
Be more robust according to shell used by the user.
Fix the issue that when you don't use fish, the rc file is not correctly setted to receive SSH_AUTH_SOCK.
Remove unnecessary ssh-add (was for debug)
Add control on SSH_AUTH_SOCK setting, if not correctly defined, return 1 and log