### PR TITLE
Cache touch for signing operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,10 +296,13 @@ Your selection? q
 
 ### git rebase
 
-Combined with the touch requirement for all signing operations, `git rebase`
-might require you to touch the YubiKey too many times. A
-[workaround](https://github.com/DataDog/yubikey/issues/19) is to pass the
-`--no-gpg-sign`.
+You can perform signing operations for 15 seconds after touching your
+yubikey before having to touch it again. When running large git rebase
+you may have to touch your yubikey multiple times, if the rebase seems
+to hang and the yubikey flashes, it means you need to touch it again.
+
+If you are still having issues when rebasing, you might consider using
+the `--no-gpg-sign` flag as a [workaround](https://github.com/DataDog/yubikey/issues/19).
 
 ### Signing for different git repositories with different keys
 

--- a/expect.sh
+++ b/expect.sh
@@ -204,7 +204,7 @@ expect eof
 # Turn on touch for SIGNATURES.
 
 send_user "Now requiring you to touch your Yubikey to sign any message.\n"
-spawn ykman openpgp set-touch sig on
+spawn ykman openpgp set-touch sig cached
 
 expect -exact "Enter admin PIN: "
 stty -echo

--- a/gpg.sh
+++ b/gpg.sh
@@ -153,7 +153,7 @@ $GPGCONF --kill all
 
 # Final reminders.
 echo "Finally, remember that your keys will not expire until 10 years from now."
-echo "You will need to ${RED}${BOLD}enter your PIN (once a day)${RESET}, and ${RED}${BOLD}touch your Yubikey everytime${RESET} in order to sign any message with this GPG key."
+echo "You will need to ${RED}${BOLD}enter your PIN (once a day)${RESET}, and ${RED}${BOLD}touch your Yubikey everytime${RESET} in order to sign any message with this GPG key. Touch is cached for 15s on sign operations."
 echo ""
 echo "************************************************************"
 echo "Your PIN is: $PIN"


### PR DESCRIPTION
With this you can perform multiple signing operations for 15 seconds after touching the yubikey (especially useful for signing commits when rebasing -> #19 )

To update your key to use this setting, run:
```
ykman openpgp set-touch sig cached
```
and enter your key admin pin (should be your PUK in your password manager)