### PR TITLE
Use which to determine gpgconf path

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -8,7 +8,7 @@ HOMEBREW_BIN=$HOMEBREW_PREFIX/bin
 export GIT=$HOMEBREW_BIN/git
 export GPG=$HOMEBREW_BIN/gpg
 export GPG_AGENT=$HOMEBREW_BIN/gpg-agent
-export GPGCONF=`which gpgconf`
+export GPGCONF="$(which gpgconf)"
 export YKMAN=$HOMEBREW_BIN/ykman
 
 # Colors galore.

--- a/env.sh
+++ b/env.sh
@@ -8,7 +8,7 @@ HOMEBREW_BIN=$HOMEBREW_PREFIX/bin
 export GIT=$HOMEBREW_BIN/git
 export GPG=$HOMEBREW_BIN/gpg
 export GPG_AGENT=$HOMEBREW_BIN/gpg-agent
-export GPGCONF=$HOMEBREW_BIN/gpgconf
+export GPGCONF=`which gpgconf`
 export YKMAN=$HOMEBREW_BIN/ykman
 
 # Colors galore.

--- a/env.sh
+++ b/env.sh
@@ -2,14 +2,11 @@
 
 # Shared environment variables.
 
-# Use Homebrew binaries.
-HOMEBREW_PREFIX=$(brew --prefix)
-HOMEBREW_BIN=$HOMEBREW_PREFIX/bin
-export GIT=$HOMEBREW_BIN/git
-export GPG=$HOMEBREW_BIN/gpg
-export GPG_AGENT=$HOMEBREW_BIN/gpg-agent
+export GIT="$(which git)"
+export GPG="$(which gpg)"
+export GPG_AGENT="$(which gpg-agent)"
 export GPGCONF="$(which gpgconf)"
-export YKMAN=$HOMEBREW_BIN/ykman
+export YKMAN="$(which ykman)"
 
 # Colors galore.
 BOLD=$(tput bold)


### PR DESCRIPTION
I recently reconfigured my yubikey and found that my existing gpg installation couldn't be used because env.sh is explicitly looking for gpgconf as installed by homebrew. Homebrew won't install gpg if it is already installed. This PR updates env.sh to use `which` to identify the correct path for gpgconf.