### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 - [Reset](#reset)
 - [Troubleshooting](#troubleshooting)
 - [Optional](#optional)
-- [TODO](#todo)
 - [References](#references)
 
 ## Summary
@@ -103,18 +102,12 @@ Go [here](docs/troubleshooting.md) for troubleshooting common issues such as unb
 
 Go [here](docs/optional.md) for support on optional bits such as Keybase, VMware Fusion, Docker Content Trust, signing for different git repositories with different keys, and configuring a computer to use an already configured Yubikey.
 
-## TODO
-
-1. Instructions for revoking and / or replacing keys.
-
-2. Procedures for recovering from key compromise / theft / loss.
-
 ## References
 
-1. [https://ruimarinho.gitbooks.io/yubikey-handbook/content/openpgp/](https://ruimarinho.gitbooks.io/yubikey-handbook/content/openpgp/)
+1. [YubiKey Handbook](https://ruimarinho.gitbooks.io/yubikey-handbook/content/openpgp/)
 
-2. [https://mikegerwitz.com/papers/git-horror-story](https://mikegerwitz.com/papers/git-horror-story)
+2. [A Git Horror Story: Repository Integrity With Signed Commits](https://mikegerwitz.com/papers/git-horror-story)
 
-3. [http://karl.kornel.us/2017/10/welp-there-go-my-git-signatures/](http://karl.kornel.us/2017/10/welp-there-go-my-git-signatures/)
+3. [Welp, there go my Git signatures](http://karl.kornel.us/2017/10/welp-there-go-my-git-signatures/)
 
-4. [https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2014-May/005877.html](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2014-May/005877.html)
+4. [[Bitcoin-development] PSA: Please sign your git commits](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2014-May/005877.html)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # YubiKey at Datadog
 
-Table of contents
-
 - [Summary](#summary)
 - [Estimated burden and prerequisites](#estimated-burden-and-prerequisites)
 - [U2F](#u2f)
@@ -99,73 +97,7 @@ $ ./reset.sh
 
 ## Troubleshooting
 
-### Blocked card
-
-If you are blocked out of using GPG because you entered your PIN wrong too
-many times (3x by default), **don’t panic**: just [follow the
-instructions](https://github.com/ruimarinho/yubikey-handbook/blob/master/openpgp/troubleshooting/gpg-failed-to-sign-the-data.md)
-here. Make sure you enter your **Admin PIN** correctly within 3x, otherwise
-your current keys are blocked, and you must reset your YubiKey to use new keys.
-
-### Error with git pull/fetch or when using SSH
-If you try to ssh or git pull/fetch and you have the following error:
-```
-sign_and_send_pubkey: signing failed: agent refused operation
-```
-You are probably mistyping your PIN. To verify it, you can:
-```
-gpg --card-edit
-gpg/card> verify
-...
-PIN retry counter : 3 0 3 # if it is the right PIN
-PIN retry counter : 2 0 3 # if it is a wrong PIN
-...
-```
-If your PIN is wrong, try 123456, which is the default PIN.
-If it still fails, reset your PIN:
-```
-gpg --card-edit
-gpg/card> admin
-gpg/card> passwd
-gpg: OpenPGP card no. D2760001240102010006055532110000 detected
-
-Your selection? 1
-PIN changed.
-
-1 - change PIN
-2 - unblock PIN
-3 - change Admin PIN
-4 - set the Reset Code
-Q - quit
-
-Your selection? q
-```
-
-### git rebase
-
-If you are using the FIPS model, you can perform signing operations for 15
-seconds after touching your YubiKey before having to touch it again. When
-running a large git rebase, you may have to touch your YubiKey multiple times.
-If the rebase seems to hang and the YubiKey flashes, it means you need to touch
-it again.
-
-If you are still having issues when rebasing, you might consider using
-the `--no-gpg-sign` flag as a [workaround](https://github.com/DataDog/yubikey/issues/19).
-
-### Error: No PyUSB backend detected!
-
-If you see the following error while running `./gpg.sh`:
-
-```
-Usage: ykman [OPTIONS] COMMAND [ARGS]...
-Try "ykman -h" for help.
-
-Error: No PyUSB backend detected!
-```
-
-Hit CTRL-C to exit the script (if the script has not already exited) and [reinstall](https://github.com/Yubico/yubikey-manager/issues/185#issuecomment-446379356) `libsub`, then try again:
-
-    `brew reinstall libusb`
+Go [here](docs/troubleshooting.md) for troubleshooting common issues such as unblocking a blocked card, error when pulling or pushing with git over SSH, and rebasing with git.
 
 ## Optional
 

--- a/docs/optional.md
+++ b/docs/optional.md
@@ -1,7 +1,5 @@
 # Optional
 
-Table of contents
-
 - [Keybase](#keybase)
 - [VMware Fusion](#vmware-fusion)
 - [Docker Content Trust](#docker-content-trust)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,73 @@
+# Troubleshooting
+
+- [Blocked card](#blocked-card)
+- [Error with git pull/fetch or when using SSH](#error-with-git-pullfetch-or-when-using-ssh)
+- [git rebase](#git-rebase)
+- [No PyUSB backend detected](#no-pyusb-backend-detected)
+
+## Blocked card
+
+If you are blocked out of using GPG because you entered your PIN wrong too
+many times (3x by default), **don’t panic**: just [follow the
+instructions](https://github.com/ruimarinho/yubikey-handbook/blob/master/openpgp/troubleshooting/gpg-failed-to-sign-the-data.md)
+here. Make sure you enter your **Admin PIN** correctly within 3x, otherwise
+your current keys are blocked, and you must reset your YubiKey to use new keys.
+
+## Error with git pull/fetch or when using SSH
+
+If you try to ssh or git pull/fetch and you have the following error:
+```
+sign_and_send_pubkey: signing failed: agent refused operation
+```
+You are probably mistyping your PIN. To verify it, you can:
+```
+gpg --card-edit
+gpg/card> verify
+...
+PIN retry counter : 3 0 3 # if it is the right PIN
+PIN retry counter : 2 0 3 # if it is a wrong PIN
+...
+```
+If your PIN is wrong, try 123456, which is the default PIN.
+If it still fails, reset your PIN:
+```
+gpg --card-edit
+gpg/card> admin
+gpg/card> passwd
+gpg: OpenPGP card no. D2760001240102010006055532110000 detected
+
+Your selection? 1
+PIN changed.
+
+1 - change PIN
+2 - unblock PIN
+3 - change Admin PIN
+4 - set the Reset Code
+Q - quit
+
+Your selection? q
+```
+
+## git rebase
+
+If you are using the FIPS model, you can perform signing operations for 15
+seconds after touching your YubiKey before having to touch it again. When
+running a large git rebase, you may have to touch your YubiKey multiple times.
+If the rebase seems to hang and the YubiKey flashes, it means you need to touch
+it again.
+
+If you are still having issues when rebasing, you might consider using
+the `--no-gpg-sign` flag as a [workaround](https://github.com/DataDog/yubikey/issues/19).
+
+## No PyUSB backend detected
+
+If you see the following error while running `./gpg.sh`:
+
+```
+Usage: ykman [OPTIONS] COMMAND [ARGS]...
+Try "ykman -h" for help.
+
+Error: No PyUSB backend detected!
+```
+
+Hit CTRL-C to exit the script (if the script has not already exited) and [reinstall](https://github.com/Yubico/yubikey-manager/issues/185#issuecomment-446379356) `libsub`, then try again: `brew reinstall libusb`


### PR DESCRIPTION
* Split troubleshooting into separate document
* Move TODO to issues [[58]](https://github.com/DataDog/yubikey/issues/58) [[59]](https://github.com/DataDog/yubikey/issues/59)
* List references using titles instead of URLs

Signed-off-by: Trishank Karthik Kuppusamy <trishank.kuppusamy@datadoghq.com>