### PR TITLE
Exit if gnupg version is 2.2.22 or 2.2.23

### DIFF
--- a/git.sh
+++ b/git.sh
@@ -3,6 +3,7 @@
 # Stop on error.
 set -e
 
+source env.sh
 source realname-and-email.sh
 
 # Set git name and email.

--- a/realname-and-email.sh
+++ b/realname-and-email.sh
@@ -3,8 +3,6 @@
 # Stop on error.
 set -e
 
-source env.sh
-
 # Get some information from the user.
 
 # 1. Real name.


### PR DESCRIPTION
Gnupg has a bug in version 2.2.22 or 2.2.23 that makes gpg.sh fails
```bash
gpg/card> generate
Make off-card backup of encryption key? (Y/n) n
Please note that the factory settings of the PINs are
   PIN = '123456'     Admin PIN = '12345678'
You should change them using the command --change-pin
gpg: error checking the PIN: End of file
gpg/card> 58072933
Invalid command  (try "help")
```
See https://dev.gnupg.org/T5086 for more details. The issue has been fixed by https://dev.gnupg.org/T5052
and will be available in 2.2.24.


So I added an exit if gnupg version is 2.2.22 or 2.2.23 and made the upgrade/install with brew optional.
I added a check before running that all binaries needed are present.
