### PR TITLE
Support GPG version >= 2.2.25

### DIFF
--- a/expect.sh
+++ b/expect.sh
@@ -194,8 +194,15 @@ send -- "$PUK\r"
 
 send_user "\nNow generating keys on card, lights will be flashing, this will take a few minutes, please wait...\n"
 
-expect -exact "gpg/card> "
-send -- "quit\r"
+# Send new PIN
+expect {
+    "PIN: " {
+        send -- "$PIN\r"
+        expect -exact "gpg/card> "
+        send -- "quit\r"
+    }
+    "gpg/card> " { send -- "quit\r" }
+}
 
 expect eof
 


### PR DESCRIPTION
The new GPG binary ask for one more pin to unlock the card after generation.
![image](https://user-images.githubusercontent.com/4062883/100805924-d6654380-342f-11eb-8356-7ae5ceef4a88.png)
This PR make the expect after the generation wait for PIN or prompt to support new and older version.

Tested on:
- Yubikey 5C FIPS nano
- Yubikey 4A
- Yubikey 5C nano