### PR TITLE
Fix an edge case when expect is not able to fill some steps

### DIFF
--- a/expect.sh
+++ b/expect.sh
@@ -16,6 +16,7 @@
 # pacifies every program I know of.  The -c flag makes the script do
 # this in the first place.  The -C flag allows you to define a
 # character to toggle this mode off and on.
+
 set force_conservative 1  ;# set to 1 to force conservative mode even if
 			  ;# script was not run conservatively originally
 if {$force_conservative} {

--- a/expect.sh
+++ b/expect.sh
@@ -16,7 +16,7 @@
 # pacifies every program I know of.  The -c flag makes the script do
 # this in the first place.  The -C flag allows you to define a
 # character to toggle this mode off and on.
-
+set stty_init -echo
 set force_conservative 1  ;# set to 1 to force conservative mode even if
 			  ;# script was not run conservatively originally
 if {$force_conservative} {

--- a/expect.sh
+++ b/expect.sh
@@ -16,7 +16,6 @@
 # pacifies every program I know of.  The -c flag makes the script do
 # this in the first place.  The -C flag allows you to define a
 # character to toggle this mode off and on.
-set stty_init -echo
 set force_conservative 1  ;# set to 1 to force conservative mode even if
 			  ;# script was not run conservatively originally
 if {$force_conservative} {

--- a/gpg.sh
+++ b/gpg.sh
@@ -178,6 +178,8 @@ export LC_ALL=en_US.UTF-8
 # drive yubikey setup
 # but right before, kill all GPG daemons to make sure things work reliably
 $GPGCONF --homedir="$GPG_HOMEDIR" --kill all
+# The script failed to run when GPG_TTY != '' so we ensure it's empty before the expect script.
+# https://gnupg.org/documentation/manuals/gnupg/Common-Problems.html
 GPG_TTY="" ./expect.sh "$TOUCH_POLICY" "$ADMIN_PIN" "$GPG_HOMEDIR" "$USER_PIN" "$KEY_LENGTH" "$REALNAME" "$EMAIL" "$COMMENT"
 echo
 

--- a/gpg.sh
+++ b/gpg.sh
@@ -178,6 +178,7 @@ export LC_ALL=en_US.UTF-8
 # drive yubikey setup
 # but right before, kill all GPG daemons to make sure things work reliably
 $GPGCONF --homedir="$GPG_HOMEDIR" --kill all
+export GPG_TTY=""
 ./expect.sh "$TOUCH_POLICY" "$ADMIN_PIN" "$GPG_HOMEDIR" "$USER_PIN" "$KEY_LENGTH" "$REALNAME" "$EMAIL" "$COMMENT"
 echo
 

--- a/gpg.sh
+++ b/gpg.sh
@@ -178,8 +178,7 @@ export LC_ALL=en_US.UTF-8
 # drive yubikey setup
 # but right before, kill all GPG daemons to make sure things work reliably
 $GPGCONF --homedir="$GPG_HOMEDIR" --kill all
-export GPG_TTY=""
-./expect.sh "$TOUCH_POLICY" "$ADMIN_PIN" "$GPG_HOMEDIR" "$USER_PIN" "$KEY_LENGTH" "$REALNAME" "$EMAIL" "$COMMENT"
+GPG_TTY="" ./expect.sh "$TOUCH_POLICY" "$ADMIN_PIN" "$GPG_HOMEDIR" "$USER_PIN" "$KEY_LENGTH" "$REALNAME" "$EMAIL" "$COMMENT"
 echo
 
 # restore initial locale value


### PR DESCRIPTION
fix #50 

Huge thanks to @ahmed-mez who find the solution. 

The script failed to run when `GPG_TTY != ''` so we ensure it's empty before the expect script.

https://gnupg.org/documentation/manuals/gnupg/Common-Problems.html