### PR TITLE
Support non-homebrew GPG

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -34,7 +34,7 @@ case $(echo "$OS" | tr "[:upper:]" "[:lower:]") in
         HOMEBREW_BIN=$HOMEBREW_PREFIX/bin
         GIT=$HOMEBREW_BIN/git
         GPG=$(which gpg)
-        GPG_AGENT=$HOMEBREW_BIN/gpg-agent
+        GPG_AGENT=$(which gpg-agent)
         GPGCONF=$(which gpgconf)
         YKMAN=$HOMEBREW_BIN/ykman
         CLIP="pbcopy"

--- a/env.sh
+++ b/env.sh
@@ -33,9 +33,9 @@ case $(echo "$OS" | tr "[:upper:]" "[:lower:]") in
         HOMEBREW_PREFIX=$(brew --prefix)
         HOMEBREW_BIN=$HOMEBREW_PREFIX/bin
         GIT=$HOMEBREW_BIN/git
-        GPG=$HOMEBREW_BIN/gpg
+        GPG=$(which gpg)
         GPG_AGENT=$HOMEBREW_BIN/gpg-agent
-        GPGCONF=$HOMEBREW_BIN/gpgconf
+        GPGCONF=$(which gpgconf)
         YKMAN=$HOMEBREW_BIN/ykman
         CLIP="pbcopy"
         CLIP_ARGS=""


### PR DESCRIPTION
`gnupg`/`gpg-agent` may not always be in this location, as such this just changes it to check for whichever place it is 👍 