### PR TITLE
Fix for open and pinentry under Ubuntu

### DIFF
--- a/git.sh
+++ b/git.sh
@@ -42,7 +42,7 @@ $GPG --armor --export "$KEYID" | $CLIP $CLIP_ARGS
 echo "It has been copied to your clipboard."
 echo "${YELLOW}You may now add it to GitHub: https://github.com/settings/gpg/new${RESET}"
 echo "${GREEN}Opening GitHub...${RESET}"
-open "https://github.com/settings/gpg/new"
+$OPEN "https://github.com/settings/gpg/new"
 echo
 
 # Turn on notifications.

--- a/gpg.sh
+++ b/gpg.sh
@@ -203,7 +203,7 @@ export LC_ALL="${old_locale}"
 # We want to replace the pinentry-tty with the pinentry-mac.
 cat << EOF > "$DEFAULT_GPG_AGENT_CONF"
 # https://www.gnupg.org/documentation/manuals/gnupg/Agent-Options.html
-pinentry-program $HOMEBREW_BIN/pinentry-mac
+pinentry-program $HOMEBREW_BIN/$PINENTRY
 # For usability while balancing security, cache User PIN for at most a day.
 default-cache-ttl 86400
 max-cache-ttl 86400


### PR DESCRIPTION
Changes to use the vars from env.sh when calling `open` and setting the `pinentry` bin in gpg-agent.

Tested working on Ubuntu, needs a test run under MacOS.