### PR TITLE
Swap title and body on macOS notification

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -52,7 +52,7 @@ case $(echo "$OS" | tr "[:upper:]" "[:lower:]") in
         )
         set +e
         read -r -d '' NOTIFICATION_CMD << EOF
-osascript -e 'display notification "git wants to sign a commit!" with title "Touch your YubiKey after submitting the User PIN"'
+osascript -e 'display notification "Touch your YubiKey after submitting the User PIN" with title "git wants to sign a commit!"'
 gpg "\$@"
 if [[ "\$?" -ne 0 ]]; then
     echo "Signing failed, exiting"

--- a/env.sh
+++ b/env.sh
@@ -52,7 +52,7 @@ case $(echo "$OS" | tr "[:upper:]" "[:lower:]") in
         )
         set +e
         read -r -d '' NOTIFICATION_CMD << EOF
-osascript -e 'display notification "Touch your YubiKey after submitting the User PIN" with title "git wants to sign a commit!"'
+osascript -e 'display notification "Touch your YubiKey after submitting the User PIN" with title "Git wants to sign a commit!"'
 gpg "\$@"
 if [[ "\$?" -ne 0 ]]; then
     echo "Signing failed, exiting"


### PR DESCRIPTION
Currently, the title on the macOS notification is cut off. This PR swaps the title and body so the full message is readable.

When I first joined Datadog and was making my first commit, I kept touching the YubiKey _before_ entering the user PIN not realizing that I was supposed to touch after. Hopefully this change helps some new person somewhere. :)
## Old
<img width="367" alt="old" src="https://user-images.githubusercontent.com/3106117/184140315-832bb56b-7a02-4648-b8a1-1430ae0ac5d3.png">

## New
<img width="367" alt="new" src="https://user-images.githubusercontent.com/3106117/184140301-e8fc477a-ed5f-4ae6-a00e-9e025ec27bc3.png">