### PR TITLE
Install python3 as dependency on ubuntu/debian

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -89,7 +89,7 @@ EOF
             "git"
             "gpg"
             "pinentry-tty"
-            "python"
+            "python3"
             "scdaemon"
             "yubikey-manager"
             "xclip"


### PR DESCRIPTION
On newer versions of Debian/Ubuntu, there is no `python` package, only `python2` or `python3`. Because the scripts use `python3` executable, let's install `python3` explicitly (`python3` as a package has been available for a long time, so backwards compatibility should be fine).