### PR TITLE
Add gpg-sign-notify script that only prompts the user if they don't touch the key within 5 seconds

### DIFF
--- a/bin/gpg-sign-notify
+++ b/bin/gpg-sign-notify
@@ -16,21 +16,11 @@ sleep_pid=$!
 # bash >= 4 thing, and the default bash on MacOS is 3, so we prioritise
 # compatibility.
 
-# This will be overwritten by the notifications.sh script
-NOTIFY_OS=macos
-
 notify() {
     local title="$1"; shift;
     local body="$1"; shift;
 
-    case $NOTIFY_OS in
-      macos)
-        osascript -e 'display notification "'"$body"'" with title "'"$title"'"'
-        ;;
-      linux)
-        notify-send "$title" "$body"
-        ;;
-    esac
+    %%NOTIFICATION_NOTIFY%%
 }
 
 reap() {

--- a/bin/gpg-sign-notify
+++ b/bin/gpg-sign-notify
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Notifies the user that they need to do something if gpg-sign takes longer than
+# 5 seconds
+
+# The explicit redirection of stdin is required, otherwise (in the absence of
+# job control) bash will bind stdin of the background process to /dev/null,
+# resulting in a bad signature/bad verification for good signatures.
+gpg "$@" </dev/fd/0 &
+gpg_pid=$!
+
+sleep 5 &
+sleep_pid=$!
+
+# The following code would be simplified by `wait -n ...` but the `-n` flag is a
+# bash >= 4 thing, and the default bash on MacOS is 3, so we prioritise
+# compatibility.
+
+# This will be overwritten by the notifications.sh script
+NOTIFY_OS=macos
+
+notify() {
+    local title="$1"; shift;
+    local body="$1"; shift;
+
+    case $NOTIFY_OS in
+      macos)
+        osascript -e 'display notification "'"$body"'" with title "'"$title"'"'
+        ;;
+      linux)
+        notify-send "$title" "$body"
+        ;;
+    esac
+}
+
+reap() {
+    # Cancel the trap, otherwise it will run again when another child exits
+    trap "" SIGCHLD
+
+    if kill -0 $gpg_pid 2>/dev/null; then
+        # GPG is still running; we assume it's waiting for input
+        notify "Git wants to sign a commit!" "Touch your YubiKey after submitting the User PIN"
+        # Make sure we exit with the gpg status
+        wait $gpg_pid
+    else
+        # GPG is not running; kill the sleep process if it's still there and exit
+        kill $sleep_pid
+        wait $gpg_pid
+        exit_status=$?
+        exit $exit_status
+    fi
+}
+
+# Run reap as soon as _any_ child exits
+trap reap SIGCHLD
+
+# Wait for all children to exit
+wait

--- a/env.sh
+++ b/env.sh
@@ -50,7 +50,9 @@ case $(echo "$OS" | tr "[:upper:]" "[:lower:]") in
             "pinentry-mac"
             "ykman"
         )
-        NOTIFICATION_OS=macos
+        read -r -d '' NOTIFICATION_NOTIFY << EOF
+osascript -e 'display notification "'"\$body"'" with title "'"\$title"'"'        
+EOF
         NOTIFICATION_SCRIPT_PATH="${USER_BIN_DIR}/yubinotif"
         SCDAEMON_CONF="disable-ccid\nreader-port \"$(pcsctest <<< 01 | grep 'Reader 01' | awk -F ': ' '{print $2}' | head -n1)\""
         export HOMEBREW_NO_AUTO_UPDATE=1
@@ -85,7 +87,9 @@ case $(echo "$OS" | tr "[:upper:]" "[:lower:]") in
             "yubikey-manager"
             "xclip"
         )
-        NOTIFICATION_OS=linux
+        read -r -d '' NOTIFICATION_NOTIFY << EOF
+notify-send "\$title" "\$body"        
+EOF
         NOTIFICATION_SCRIPT_PATH="${USER_BIN_DIR}/yubinotif"
         SCDAEMON_CONF=""
         if ! grep -rqE '^deb http://ppa.launchpad.net/yubico/stable/ubuntu' /etc/apt/sources.list.d/*.list; then
@@ -123,7 +127,9 @@ case $(echo "$OS" | tr "[:upper:]" "[:lower:]") in
             "pcsclite"
         )
         set +e
-        NOTIFICATION_OS=linux
+        read -r -d '' NOTIFICATION_NOTIFY << EOF
+notify-send "\$title" "\$body"        
+EOF
         NOTIFICATION_SCRIPT_PATH="${USER_BIN_DIR}/yubinotif"
         # shellcheck disable=SC2034
         SCDAEMON_CONF=""

--- a/env.sh
+++ b/env.sh
@@ -50,16 +50,7 @@ case $(echo "$OS" | tr "[:upper:]" "[:lower:]") in
             "pinentry-mac"
             "ykman"
         )
-        set +e
-        read -r -d '' NOTIFICATION_CMD << EOF
-osascript -e 'display notification "Touch your YubiKey after submitting the User PIN" with title "Git wants to sign a commit!"'
-gpg "\$@"
-if [[ "\$?" -ne 0 ]]; then
-    echo "Signing failed, exiting"
-fi
-echo "Sign completed"
-EOF
-        set -e
+        NOTIFICATION_OS=macos
         NOTIFICATION_SCRIPT_PATH="${USER_BIN_DIR}/yubinotif"
         SCDAEMON_CONF="disable-ccid\nreader-port \"$(pcsctest <<< 01 | grep 'Reader 01' | awk -F ': ' '{print $2}' | head -n1)\""
         export HOMEBREW_NO_AUTO_UPDATE=1
@@ -94,16 +85,7 @@ EOF
             "yubikey-manager"
             "xclip"
         )
-        set +e
-        read -r -d '' NOTIFICATION_CMD << EOF
-notify-send 'git wants to sign a commit!' 'Touch your YubiKey after submitting the User PIN'
-gpg "\$@"
-if [[ "\$?" -ne 0 ]]; then
-    echo "Signing failed, exiting"
-fi
-echo "Sign completed"
-EOF
-        set -e
+        NOTIFICATION_OS=linux
         NOTIFICATION_SCRIPT_PATH="${USER_BIN_DIR}/yubinotif"
         SCDAEMON_CONF=""
         if ! grep -rqE '^deb http://ppa.launchpad.net/yubico/stable/ubuntu' /etc/apt/sources.list.d/*.list; then
@@ -141,15 +123,7 @@ EOF
             "pcsclite"
         )
         set +e
-        read -r -d '' NOTIFICATION_CMD << EOF
-notify-send 'git wants to sign a commit!' 'Touch your YubiKey after submitting the User PIN'
-gpg "\$@"
-if [[ "\$?" -ne 0 ]]; then
-    echo "Signing failed, exiting"
-fi
-echo "Sign completed"
-EOF
-        set -e
+        NOTIFICATION_OS=linux
         NOTIFICATION_SCRIPT_PATH="${USER_BIN_DIR}/yubinotif"
         # shellcheck disable=SC2034
         SCDAEMON_CONF=""

--- a/lib/notifications.sh
+++ b/lib/notifications.sh
@@ -15,7 +15,7 @@ set -e
 mkdir -p "$USER_BIN_DIR"
 
 echo "Deploying the notifications script"
-echo -e "$NOTIFICATION_CMD" > "$NOTIFICATION_SCRIPT_PATH"
+sed -E -e 's/^(NOTIFY_OS=).*/\1'"$NOTIFICATION_OS"'/' bin/gpg-sign-notify > "$NOTIFICATION_SCRIPT_PATH"
 chmod u+x "$NOTIFICATION_SCRIPT_PATH"
 echo "${GREEN}The notifications script has been deployed${RESET}"
 

--- a/lib/notifications.sh
+++ b/lib/notifications.sh
@@ -15,7 +15,7 @@ set -e
 mkdir -p "$USER_BIN_DIR"
 
 echo "Deploying the notifications script"
-sed -E -e 's/^(NOTIFY_OS=).*/\1'"$NOTIFICATION_OS"'/' bin/gpg-sign-notify > "$NOTIFICATION_SCRIPT_PATH"
+sed -E -e 's/%%NOTIFICATION_NOTIFY%%/'"$NOTIFICATION_NOTIFY"'/' bin/gpg-sign-notify > "$NOTIFICATION_SCRIPT_PATH"
 chmod u+x "$NOTIFICATION_SCRIPT_PATH"
 echo "${GREEN}The notifications script has been deployed${RESET}"
 


### PR DESCRIPTION
Works best with cached signing on.  The script avoids prompting the user for every commit (which is annoying, especially when running `git rebase`); instead, if the yubikey isn't touched within 5 seconds, the user is prompted (probably because they forgot).  If the key _is_ touched within the 5 seconds, no prompt appears.

I've been using this script on macOS for a couple of months; it seems reasonably robust.  I haven't tested the linux version (which you'd get by modifying `NOTIFY_OS` to be linux [here](https://github.com/DataDog/yubikey/blob/be0143d087f722f321455cf9a6adfd1153faa685/bin/gpg-sign-notify#L20)).